### PR TITLE
Improved flexibility

### DIFF
--- a/fMRI-MAE/config.yaml
+++ b/fMRI-MAE/config.yaml
@@ -1,5 +1,5 @@
 # Model Config
-model_name: "testing"
+model_name: "patch8"
 use_cls_token: False
 use_contrastive_loss: False
 constrastive_loss_weight: 1.0
@@ -17,7 +17,7 @@ cache_dir: "cache/"
 ckpt_saving: True
 ckpt_interval: 50
 resume_from_ckpt: False
-wandb_log: False
+wandb_log: True
 
 # MAE Config
 tube_mask_ratio: 0.75
@@ -35,5 +35,5 @@ use_rope_emb: False
 # Data Config
 img_size: [64, 64, 48] # Image Size
 num_frames: 4
-train_urls: "s3://proj-fmri/fmri_foundation_datasets/openneuro/{000011..000664}.tar"
-test_urls: "s3://proj-fmri/fmri_foundation_datasets/openneuro/{000000..000010}.tar"
+train_urls: "s3://proj-fmri/fmri_foundation_datasets/openneuro/{000005..000664}.tar"
+test_urls: "s3://proj-fmri/fmri_foundation_datasets/openneuro/{000000..000004}.tar"


### PR DESCRIPTION
- Fixed some hard-coded parts of code to be more flexible (e.g., changing patch_dim is now possible)
- Removed test_cache_dir as it was leading to errors if different from cache_dir
- Decreased default test_urls to 5 tars instead of 10 to make it faster
- Now test set is exhaustively (i.e,. all samples) evaluated every epoch rather than a single batch
- Removed unnecessary whitespaces done from prior pre-commits
- Now skipping batches where there arent enough brain-positive patches to separately have the desired number of independent encoder and decoder patches 