### PR TITLE
add dropout like masking

### DIFF
--- a/fMRI-MAE/config.yaml
+++ b/fMRI-MAE/config.yaml
@@ -1,5 +1,5 @@
 # Model Config
-model_name: "patch8"
+model_name: "patch8_base1"
 use_cls_token: False
 use_contrastive_loss: False
 constrastive_loss_weight: 1.0
@@ -15,12 +15,13 @@ cache_dir: "cache/"
 
 # Saving progress
 ckpt_saving: True
-ckpt_interval: 50
+ckpt_interval: 20
 resume_from_ckpt: False
 wandb_log: True
 
 # MAE Config
-tube_mask_ratio: 0.75
+tube_start_masking_ratio: 0.75
+tube_end_masking_ratio: 0.75
 decoder_mask_ratio: 0.75
 
 # Model Config

--- a/fMRI-MAE/models.py
+++ b/fMRI-MAE/models.py
@@ -295,7 +295,8 @@ class SimpleViT(nn.Module):
         else:  # DECODER
             if verbose: print(x.shape)
             x = self.encoder_to_decoder(x)
-            B, N, _ = x.shape
+            B, _, _ = x.shape
+            N = decoder_mask.sum()
             mask = None
             if not self.use_rope_emb:
                 if verbose: print(x.shape)
@@ -309,9 +310,7 @@ class SimpleViT(nn.Module):
                     cls_tokens = x[:,:1,:]
                     x = x[:,1:,:]
                 x = torch.cat([x + pos_emd_encoder, 
-                               self.mask_token.repeat(B, 
-                               N-1 if self.use_cls_token else N, 1) 
-                               + pos_emd_decoder], 
+                               self.mask_token.repeat(B, N, 1) + pos_emd_decoder], 
                               dim=1)
                 if self.use_cls_token:
                     x = torch.cat([cls_tokens, x], dim=1)


### PR DESCRIPTION
- Add option to increase the masking ratio for the encoder from x to y across training.
- Add an exception handler to skip files which are corrupted. Eg. if `func.png` is not present for a data point.