### PR TITLE
Ckadirt/flash attention on vit

### DIFF
--- a/fMRI-MAE/main.ipynb
+++ b/fMRI-MAE/main.ipynb
@@ -86,6 +86,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "750d1865-e348-4693-8066-19f37eb36a9b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "0d58682c-0cb8-4bea-9a3c-6afbddb49316",
    "metadata": {
     "tags": []
@@ -194,26 +202,27 @@
     "decoder_mask = torch.zeros(num_patches).to(device).to(torch.bool)\n",
     "decoder_mask[-num_decoder_patches:] = True\n",
     "with torch.no_grad():\n",
-    "    print(\"\\nencoder\")\n",
-    "    encoder_out = model(\n",
-    "                torch.randn(6, 1, 4, 64, 64, 48).to(device),\n",
-    "                encoder_mask=encoder_mask,\n",
-    "                verbose=True)\n",
-    "    print(\"\\ndecoder\")\n",
-    "    decoder_out = model(\n",
-    "                encoder_out, \n",
-    "                encoder_mask=encoder_mask, \n",
-    "                decoder_mask=decoder_mask, \n",
-    "                verbose=True)\n",
-    "    if use_cls_token:\n",
-    "        enc_cls_token = encoder_out[:, :1, :]\n",
-    "        encoder_patches = encoder_out[:, 1:, :]\n",
-    "        dec_cls_token = decoder_out[:, :1, :]\n",
-    "        decoder_patches = decoder_out[:, 1:, :]\n",
-    "        print(\"\\nenc_cls_token\", enc_cls_token.shape)\n",
-    "        print(\"encoder_patches\", encoder_patches.shape)\n",
-    "        print(\"dec_cls_token\", dec_cls_token.shape)\n",
-    "        print(\"decoder_patches\", decoder_patches.shape)"
+    "    with torch.cuda.amp.autocast(dtype=torch.float16):\n",
+    "        print(\"\\nencoder\")\n",
+    "        encoder_out = model(\n",
+    "                    torch.randn(6, 1, 4, 64, 64, 48).to(device),\n",
+    "                    encoder_mask=encoder_mask,\n",
+    "                    verbose=True)\n",
+    "        print(\"\\ndecoder\")\n",
+    "        decoder_out = model(\n",
+    "                    encoder_out, \n",
+    "                    encoder_mask=encoder_mask, \n",
+    "                    decoder_mask=decoder_mask, \n",
+    "                    verbose=True)\n",
+    "        if use_cls_token:\n",
+    "            enc_cls_token = encoder_out[:, :1, :]\n",
+    "            encoder_patches = encoder_out[:, 1:, :]\n",
+    "            dec_cls_token = decoder_out[:, :1, :]\n",
+    "            decoder_patches = decoder_out[:, 1:, :]\n",
+    "            print(\"\\nenc_cls_token\", enc_cls_token.shape)\n",
+    "            print(\"encoder_patches\", encoder_patches.shape)\n",
+    "            print(\"dec_cls_token\", dec_cls_token.shape)\n",
+    "            print(\"decoder_patches\", decoder_patches.shape)"
    ]
   },
   {
@@ -919,7 +928,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -933,7 +942,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/fMRI-MAE/models/vision_transformer.py
+++ b/fMRI-MAE/models/vision_transformer.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 from einops import rearrange
 from einops.layers.torch import Rearrange
 from rope import RotaryPositionalEmbeddings4D
+from flash_attn import flash_attn_qkvpacked_func, flash_attn_func
 
 def posemb_sincos_4d(patches, temperature=10000, dtype=torch.float32):
     _, f, d, h, w, dim, device, dtype = (*patches.shape, patches.device, patches.dtype)
@@ -168,7 +169,7 @@ class Transformer(nn.Module):
             self.layers.append(
                 nn.ModuleList(
                     [
-                        Flash_Attention(
+                        FlashAttention(
                             embed_dim,
                             num_heads=num_heads,
                             dim_head=dim_head,

--- a/fMRI-MAE/models/vision_transformer.py
+++ b/fMRI-MAE/models/vision_transformer.py
@@ -103,6 +103,45 @@ class Attention(nn.Module):
         out = torch.matmul(attn, v)
         out = rearrange(out, "b h n d -> b n (h d)")
         return self.to_out(out)
+    
+    
+class FlashAttention(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int = 8,
+        dim_head: int = 64,
+        use_rope: bool = False,
+        cls_token: bool = False,
+    ):
+        super().__init__()
+        inner_dim = dim_head * num_heads
+        self.dim_head = dim_head
+        self.num_heads = num_heads
+        self.scale = dim_head ** -0.5
+        self.use_rope = use_rope
+        self.cls_token = cls_token
+        self.norm = nn.LayerNorm(embed_dim)
+        self.to_qkv = nn.Linear(embed_dim, inner_dim * 3, bias=False)
+        self.to_out = nn.Linear(inner_dim, embed_dim, bias=False)
+        self.inner_dim = inner_dim
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        pos_embed: Optional[nn.Module],
+        mask: Optional[torch.Tensor] = None,
+    ):
+        x = self.norm(x)
+        qkv = self.to_qkv(x) # batch_size x seq_len x (3 * inner_dim) 
+        qkv = rearrange(qkv, 'b s (qkv d) -> b s qkv d', qkv=3, d=self.inner_dim)
+        qkv = rearrange(qkv, 'b s qkv (h d) -> b s qkv h d', h=self.num_heads)
+        # Using FlashAttention
+        attn_output = flash_attn_qkvpacked_func(qkv, dropout_p=0.0, softmax_scale=None, causal=False)
+        attn_output = rearrange(attn_output, 'b s h d -> b s (h d)')
+        out = self.to_out(attn_output)
+        return out
+    
 
 
 class Transformer(nn.Module):
@@ -129,7 +168,7 @@ class Transformer(nn.Module):
             self.layers.append(
                 nn.ModuleList(
                     [
-                        Attention(
+                        Flash_Attention(
                             embed_dim,
                             num_heads=num_heads,
                             dim_head=dim_head,

--- a/setup.sh
+++ b/setup.sh
@@ -9,3 +9,5 @@ python3.11 -m venv fmri
 source fmri/bin/activate
 
 pip install numpy matplotlib jupyter jupyterlab_nvdashboard jupyterlab scipy tqdm scikit-learn scikit-image accelerate webdataset pandas matplotlib einops ftfy regex h5py torchvision torch==2.1.0 transformers xformers torchmetrics deepspeed wandb nilearn nibabel boto3 open_clip_torch kornia
+
+pip install flash-attn --no-build-isolation


### PR DESCRIPTION
- Replacing the manually implemented attention code with the flash_attention function on the VITs to optimize memory and speed. 
- Adding autocast on main.ipynb since flash attention just works with fp16 and bf16.